### PR TITLE
Handle exception when reading plist files

### DIFF
--- a/collectors/suspicious.py
+++ b/collectors/suspicious.py
@@ -63,8 +63,12 @@ class SuspiciousBehaviorCollector(Collector):
 				continue
 			
 			# Read the plist data into a dictionary
-			plistDict = FoundationPlist.readPlist(onePath)
-			if not plistDict:
+			try:
+				plistDict = FoundationPlist.readPlist(onePath)
+				if not plistDict:
+					print "Error interpreting contents of {0}".format(onePath)
+					continue
+			except FoundationPlist.NSPropertyListSerializationException:
 				print "Error interpreting contents of {0}".format(onePath)
 				continue
 			


### PR DESCRIPTION
Hi,

While testing PICT, I found that the suspicious behavior module failed on a machine that had an empty plist file.
This code handles the exception raised in that situation so the module doesn't fail completely.

Cheers