### PR TITLE
Fix encoding issue on chrome extensions collector

### DIFF
--- a/collectors/browser.py
+++ b/collectors/browser.py
@@ -154,7 +154,7 @@ class BrowserExtCollector(Collector):
 					#end if extName.startswith("__MSG_")
 			
 					output += "    Extension: {0}\n".format(extPath)
-					output += "    Name: {0}\n\n".format(extName)
+					output += "    Name: {0}\n\n".format(extName.encode('utf-8'))
 				#end for extension
 			#end for profile
 		#end for user


### PR DESCRIPTION
While testing PICT on a machine, I got the following exception:

`UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 12: ordinal not in range(128)`

Encoding the string to utf-8 fixes the issue.